### PR TITLE
Fix LoadedAssetBundle referent count error. Wrap BaseLoader as AssetLoader.

### DIFF
--- a/demo/Assets/ScriptsForAssetBundleSystem/AssetLoader.cs
+++ b/demo/Assets/ScriptsForAssetBundleSystem/AssetLoader.cs
@@ -1,0 +1,52 @@
+﻿using UnityEngine;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+public class AssetLoader : BaseLoader
+{
+	private static AssetLoader msInstance = null;
+	private const string ObjectName = "AssetLoader";
+
+	public static AssetLoader Instance
+	{
+		get
+		{
+			if (msInstance == null)
+			{
+				msInstance = new GameObject( ObjectName, typeof( AssetLoader ) ).GetComponent<AssetLoader>();
+			}
+
+			return msInstance;
+		}
+	}
+
+	private static bool isReady = false;
+
+	public bool IsReady
+	{
+		get
+		{
+			return isReady;
+		}
+	}
+
+	IEnumerator Start()
+	{
+		yield return StartCoroutine( Initialize() );
+		isReady = true;
+	}
+
+	public static void LoadRequest( string assetBundleName, string assetName, Action<UnityEngine.Object> callback )
+	{
+		AssetLoader.Instance.StartCoroutine( AssetLoader.Instance.Load( assetBundleName, assetName, ( assetObject ) =>
+		{
+			if (callback != null)
+			{
+				callback( assetObject );
+			}
+
+			AssetBundleManager.UnloadAssetBundle( assetBundleName );
+		} ) );
+	}
+}

--- a/demo/Assets/ScriptsForAssetBundleSystem/AssetLoader.cs.meta
+++ b/demo/Assets/ScriptsForAssetBundleSystem/AssetLoader.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: cadc3e6dc00891c4dab57f1441378781
+timeCreated: 1427104637
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/demo/Assets/ScriptsForAssetBundleSystem/BaseLoader.cs
+++ b/demo/Assets/ScriptsForAssetBundleSystem/BaseLoader.cs
@@ -1,4 +1,5 @@
 ﻿using UnityEngine;
+using System;
 using System.Collections;
 #if UNITY_EDITOR	
 using UnityEditor;
@@ -101,22 +102,24 @@ public class BaseLoader : MonoBehaviour {
 		}
 	}
 
-	protected IEnumerator Load (string assetBundleName, string assetName)
+	protected IEnumerator Load( string assetBundleName, string assetName, Action<UnityEngine.Object> callback )
 	{
 		Debug.Log("Start to load " + assetName + " at frame " + Time.frameCount);
 
 		// Load asset from assetBundle.
-		AssetBundleLoadAssetOperation request = AssetBundleManager.LoadAssetAsync(assetBundleName, assetName, typeof(GameObject) );
+		AssetBundleLoadAssetOperation request = AssetBundleManager.LoadAssetAsync(assetBundleName, assetName, typeof(UnityEngine.Object) );
 		if (request == null)
 			yield break;
 		yield return StartCoroutine(request);
 
 		// Get the asset.
-		GameObject prefab = request.GetAsset<GameObject> ();
+		UnityEngine.Object prefab = request.GetAsset<UnityEngine.Object>();
 		Debug.Log(assetName + (prefab == null ? " isn't" : " is")+ " loaded successfully at frame " + Time.frameCount );
 
-		if (prefab != null)
-			GameObject.Instantiate(prefab);
+		if (prefab != null && callback != null)
+		{
+			callback( prefab );
+		}
 	}
 
 	protected IEnumerator LoadLevel (string assetBundleName, string levelName, bool isAdditive)


### PR DESCRIPTION
bug reappear:

const string assetBundleName = "test.unity3d";
void Start()
{
StartCoroutine(MyLoad());
StartCoroutine(MyLoad());
}

IEnumerator MyLoad()
{
Load (assetBundleName, assetName)
// Unload assetBundles.
AssetBundleManager.UnloadAssetBundle(assetBundleName);
}